### PR TITLE
update pylintrc config

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -3,7 +3,8 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=fiona
+extension-pkg-whitelist=fiona,
+                        pycurl
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
@@ -394,7 +395,8 @@ good-names=i,
            x,
            y,
            z,
-           id
+           id,
+           logger
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=n


### PR DESCRIPTION
Lint warns that `logger` is a constant name and assumes it to be lowercase. I think it should be in `good-names` list because that name is the common practice in our projects.
- Add `logger` to `good-names` list

Lint warns that `pycurl` source is unavailable, and lint have no information about `pycurl` content which is used e.g. in ntripbrowser.
- Add `pycurl` to extension-pkg-whitelist