### PR TITLE
update pylintrc config

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -4,7 +4,8 @@
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
 extension-pkg-whitelist=fiona,
-                        pycurl
+                        pycurl,
+                        alsaaudio
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.


### PR DESCRIPTION
Lint warns that alsaaudio source is unavailable, and lint have no information about alsaaudio content which is used e.g. in reach-sound.

Add alsaaudio to extension-pkg-whitelist