### PR TITLE
Gitlint configuration

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -1,0 +1,17 @@
+[general]
+ignore=body-is-missing
+
+[title-max-length]
+line-length=80
+
+[title-match-regex]
+regex=.*: .*
+
+[body-max-line-length]
+line-length=200
+
+[body-min-length]
+min-length=5
+
+[author-valid-email]
+regex=.+@emlid.com


### PR DESCRIPTION
A config for Gitlint to check that our PRs comply with our internal git guidelines:

Gitlint provides very sane default [rules](http://jorisroovers.github.io/gitlint/rules/). I've only tweaked a couple of things:

- Allowed bodiless commits
- Checked we have a scope with a `:`
- Removed body line length limits since we sometimes do ASCII drawings
- Added a check the commit are made with @emlid.com emails