### PR TITLE
Front end linters' configuration files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+FE_NODE_ESLINT_DEPENDENCIES := @vue/cli-plugin-eslint @vue/eslint-config-typescript eslint-config-airbnb-base
+FE_NODE_STYLELINT_DEPENDENCIES := stylelint-config-standard
+
+hint:
+	( \
+		echo "Actions:"; \
+		echo "  make fe – link front end configuration files to the root of the project"; \
+	)
+
+.PHONY: fe
+fe:
+	( \
+		npm install --prefix ../ --save-dev $(FE_NODE_ESLINT_DEPENDENCIES) $(FE_NODE_STYLELINT_DEPENDENCIES); \
+		echo "npm dependencies successfully installed"; \
+		ln fe/.stylelintrc ../.stylelintrc; \
+		ln fe/.eslintrc.js ../.eslintrc.js; \
+		ln fe/.editorconfig ../.editorconfig; \
+		echo "Front end configuration files are successfully linked!"; \
+	)

--- a/fe/.editorconfig
+++ b/fe/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/fe/.eslintrc.js
+++ b/fe/.eslintrc.js
@@ -1,0 +1,48 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true
+  },
+  extends: ['plugin:vue/essential', '@vue/typescript', 'airbnb-base'],
+  rules: {
+    // Enforce line breaks between array elements
+    'array-element-newline': ['error', { 'multiline': true, 'minItems': 3 }],
+
+    // Do not enforce class method to utilize `this`
+    'class-methods-use-this': 'off',
+
+    // Require trailing commas for multiline statements
+    'comma-dangle': ['error', {
+      arrays: 'only-multiline',
+      objects: 'only-multiline',
+      imports: 'never',
+      exports: 'never',
+      functions: 'never',
+    }],
+
+    // Do not enforce `require` to be called only in the top level of a module
+    'global-require': 'off',
+
+    // Ignore `import` statements with Webpack `@` alias in path
+    'import/no-unresolved': ['error', { ignore: ['^@'] }],
+
+    // Do not permit `console` references or `debugger` statements in production bundle
+    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+
+    // Base indent of 2 spaces in `.vue` files
+    'vue/script-indent': ['error', 2, { 'baseIndent': 1 }]
+  },
+  'overrides': [
+    {
+      // Disable default ESLint indentation rule for `.vue` files `<script>` section
+      'files': ['*.vue'],
+      'rules': {
+        'indent': 'off'
+      }
+    }
+  ],
+  parserOptions: {
+    parser: '@typescript-eslint/parser'
+  }
+};

--- a/fe/.stylelintrc
+++ b/fe/.stylelintrc
@@ -1,0 +1,33 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "at-rule-no-vendor-prefix": true,
+    "color-hex-case": "lower",
+    "comment-whitespace-inside": "always",
+    "declaration-block-trailing-semicolon": "always",
+    "declaration-colon-space-after": "always",
+    "declaration-colon-space-before": "never",
+    "function-url-quotes": "always",
+    "indentation": 2,
+    "length-zero-no-unit": [true, {
+      "ignoreCase": ["custom-properties"]
+    }],
+    "media-feature-colon-space-after": "always"
+    "media-feature-colon-space-before": "never",
+    "media-feature-name-no-vendor-prefix": true,
+    "media-feature-range-operator-space-after": "always",
+    "media-feature-range-operator-space-before": "always",
+    "no-duplicate-selectors": true,
+    "number-leading-zero": "always",
+    "property-no-vendor-prefix": true,
+    "rule-empty-line-before": ["always", {
+      "except": ["first-nested"]
+    }],
+    "selector-attribute-brackets-space-inside": "always",
+    "selector-list-comma-newline-after": null,
+    "selector-no-vendor-prefix": true,
+    "selector-pseudo-class-parentheses-space-inside": "always",
+    "string-quotes": "single",
+    "value-no-vendor-prefix": true,
+  }
+}


### PR DESCRIPTION
## Summary

Add configuration files for front end development:
- [ESLint](https://eslint.org) configuration based on "Airbnb base", "Vue TypeScript" and "Vue essential" rule sets
- [Stylelint](https://stylelint.io) configuration based on `stylelint-config-standard` rule set
- [Editor config](https://editorconfig.org)

Follow links above for details about the purpose of each config.


## Makefile

This PR also adds Makefile to automate configuration setup.

At the moment Makefile contains two targets:
- `hint` (default) - show hint with all possible targets;
- `fe` - install `npm` dev dependencies for linters & link linters' configs.

Note that `fe` target will link install/everything to the root of the repository. For repositories with complex structure all action have to be performed manually. 