### PR TITLE
gitlint: force 72 chars in title

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -4,7 +4,7 @@ ignore-fixup-commits=false
 ignore-squash-commits=false
 
 [title-max-length]
-line-length=80
+line-length=72
 
 [title-match-regex]
 regex=.*: .*


### PR DESCRIPTION
It looks like 80 chars are not rendered right on GH. 72 seems to be
the answer.

https://www.midori-global.com/blog/2018/04/02/git-50-72-rule