### PR TITLE
gitlint: allow commits from dependabot

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -16,7 +16,7 @@ line-length=200
 min-length=5
 
 [author-valid-email]
-regex=.+@emlid.com
+regex=(.+@emlid.com|.+(dependabot)\[(bot)\]@users.noreply.github.com)
 
 [title-must-not-contain-word]
 words=fixup,squash


### PR DESCRIPTION
## Description
We've started to use dependabot for some of our projects, but current gitlint forbid commits from non-emlid authors
## Solution
Add regex for dependabot email (49699333+dependabot[bot]@users.noreply.github.com)