### PR TITLE
gitlint: make git commit title prefixes stricter

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -7,7 +7,7 @@ ignore-squash-commits=false
 line-length=72
 
 [title-match-regex]
-regex=^((?!(fixup|amend|squash)!).)*: .*
+regex=^((?!(fixup|amend|squash)!)).*: .*
 
 [body-max-line-length]
 line-length=200

--- a/git/gitlint
+++ b/git/gitlint
@@ -7,7 +7,7 @@ ignore-squash-commits=false
 line-length=72
 
 [title-match-regex]
-regex=.*: .*
+regex=^((?!(fixup|amend|squash)!).)*: .*
 
 [body-max-line-length]
 line-length=200
@@ -17,6 +17,3 @@ min-length=5
 
 [author-valid-email]
 regex=(.+@emlid.com|.+(dependabot)\[(bot)\]@users.noreply.github.com)
-
-[title-must-not-contain-word]
-words=fixup,squash


### PR DESCRIPTION
**ClickUp**: https://app.clickup.com/t/4727576/CLD-145

## Motivation

The current filters are too loose and commit messages like this are not allowed by `gitlint`:

![image](https://user-images.githubusercontent.com/44399142/145190986-20d03759-29d0-4f75-9d49-405cabc87aac.png)

## Solution

The problem is with the current `title-must-not-contain-word` rule:
https://github.com/emlid/code-quality/blob/7c7b1a894eec35b76d6b55116d24d997b953e82e/git/gitlint#L21-L22

It should be made stricter by adding `!` at the end of each word. According to [docs](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt) there are three possible prefixes like this: `fixup!`, `amend!` and `squash!`.

Unfortunately, `title-must-not-contain-word ` doesn't work because of [regex](https://github.com/jorisroovers/gitlint/blob/594ea4d3517d5ae2e0f4f3101f89124f7ebf48b1/gitlint-core/gitlint/rules.py#L144) `\b{word}\b`, which considers `!` as a separate word. As result, `title-match-regex` has been fixed with negative lookahead.

## TODO
- [ ] squash `fixup!` commit before merging.