### PR TITLE
python: add black config

### DIFF
--- a/python/black
+++ b/python/black
@@ -1,0 +1,4 @@
+[tool.black]
+line-length=120
+check=true
+diff=true


### PR DESCRIPTION
I've added the [black config file](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file) that we use to lint python code.