### PR TITLE
Add ruff configuration

### DIFF
--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,0 +1,77 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8
+target-version = "py38"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 # Same as Black.
-line-length = 88
+line-length = 120
 indent-width = 4
 
 # Assume Python 3.8

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -46,8 +46,15 @@ select = [
     "W",
     # Pyflakes,
     "F",
+    # Pylint,
+    "PL",
 ]
-ignore = []
+ignore = [
+  # those are not yet supported by ruff
+  # "PLC0114",  # missing-module-docstring
+  # "PLC0115",  # missing-class-docstring
+  # "PLC0116",  # missing-function-docstring
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -39,7 +39,14 @@ target-version = "py38"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = [
+    # pycodestyle errors
+    "E",
+    # pycodestyle warnings
+    "W",
+    # Pyflakes,
+    "F",
+]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
As you may know, [Ruff](https://docs.astral.sh/ruff/) is a linter and a code formatter. It is extremely fast. Also, it is compatible with Black (that is used by the Cloud team), and mostly with Pylint and Flake8, that are used by the Embedded team.

I've checked it over the reach-platform repo, and the results are the following:

- It takes around 0.3–0.4 s to format 842 files
  ```
  672 files would be reformatted, 170 files already formatted
  python3.8 -m pipenv run ruff format --config ../code-quality/python/ruff.toml  0.48s user 0.04s system 162% cpu 0.321 total
  ```

- And the same time is required to lint them for errors:
  ```
  Found 210 errors.
  [*] 48 fixable with the `--fix` option (5 hidden fixes can be enabled with the `--unsafe-fixes` option).
  python3.8 -m pipenv run ruff check --config ../code-quality/python/ruff.toml  0.25s user 0.06s system 101% cpu 0.305 total
  ```

It is fairly easy to integrate into CI\CD workflow, as basically the usage is the following:
- `ruff check` performs linting and exits with non-zero code, if something goes wrong
- `ruff format --check` performs code style checks and exits with non-zero code, if something goes wrong
- `ruff format` can be used locally to format the code before pushing it

One formatter for all teams!
