### PR TITLE
Add C++ clang configuration

### DIFF
--- a/cpp/clang/.clang-format
+++ b/cpp/clang/.clang-format
@@ -1,0 +1,139 @@
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Right
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: Always
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: true
+BreakArrays: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarations: Never
+BreakBeforeInlineASMColon: Never
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 90
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentAccessModifiers: true
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+InsertBraces: true  # Be extra careful with that
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  Decimal: 3
+  Hex: 0
+JavaScriptQuotes: Double
+JavaScriptWrapImports: true
+KeepEmptyLinesAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 4
+PenaltyBreakBeforeFirstCallParameter: 4
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+QualifierAlignment: Left
+ReferenceAlignment: Left
+ReflowComments: true
+RemoveParentheses: MultipleParentheses
+RemoveSemicolon: true
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes: CaseInsensitive
+SortUsingDeclarations: Lexicographic
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        c++20
+TabWidth:        4
+UseTab:          Never
+...

--- a/cpp/clang/.clang-tidy
+++ b/cpp/clang/.clang-tidy
@@ -1,0 +1,50 @@
+Checks: >-
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -boost-*,
+  -darwin-*,
+  -fuchsia-*,
+  -mpi-*,
+  -objc-*,
+  -openmp-*,
+  -zircon-*,
+  -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -llvmlibc-callee-namespace,
+  -llvmlibc-implementation-in-namespace,
+  -llvmlibc-restrict-system-libc-headers,
+  -misc-include-cleaner,
+  -modernize-use-trailing-return-type
+
+WarningsAsErrors: '*'
+FormatStyle: 'file'
+CheckOptions:
+  - { key: readability-magic-numbers.IgnoredIntegerValues, value: '-1;0;1' }
+  - { key: readability-identifier-length.IgnoredVariableNames, value: (fd|tv|it) }
+  - { key: readability-identifier-length.IgnoredParameterNames, value: (fd|tv|it) }
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.ClassMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberPrefix, value: 'm_' }
+  - { key: readability-identifier-naming.ClassMethodCase, value: camelBack }
+  - { key: readability-identifier-naming.ClassMethodIgnoredRegexp, value: '^IP.*' }
+  - { key: readability-identifier-naming.ConstexprVariableCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack }
+  - { key: readability-identifier-naming.GlobalConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberCase, value: lower_case }
+  - { key: readability-identifier-naming.MethodCase, value: camelBack }
+  - { key: readability-identifier-naming.NamespaceCase, value: CamelCase }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.StaticConstantCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.StaticVariableCase, value: lower_case }
+  - { key: readability-identifier-naming.StructCase, value: lower_case }
+  - { key: readability-identifier-naming.StructSuffix, value: '_t' }
+  - { key: readability-identifier-naming.TypeAliasCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypedefCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }

--- a/cpp/clang/clang-format.sh
+++ b/cpp/clang/clang-format.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Default directories to check
+DIRS_TO_CHECK="include"
+EXCLUDED_DIRS=""
+
+for i in "$@"
+do
+case $i in
+    -f|--fix)
+    FIX=true
+    shift
+    ;;
+    --include-dirs=*)
+    DIRS_TO_CHECK="${i#*=}"
+    shift
+    ;;
+    --exclude-dirs=*)
+    EXCLUDED_DIRS="${i#*=}"
+    shift
+    ;;
+    *)
+    echo "Not supported arg"
+    exit 1
+    ;;
+esac
+done
+
+if [ ! -f .clang-format ]; then
+    echo ".clang-format not found! Make ./code-quality/cpp/clang/setup-clang-config.sh to fix it."
+    exit 1
+fi
+
+CLANG_FORMAT_BIN=clang-format-17
+
+SRC_TO_CHECK=$(find ${DIRS_TO_CHECK} ${EXCLUDED_DIRS} -name "*.h" -or -name "*.cpp")
+
+if [[ ! $FIX ]]; then
+    $CLANG_FORMAT_BIN -style=file -output-replacements-xml $SRC_TO_CHECK | grep "<replacement " > /dev/null 2>&1
+
+    if [[ $? -eq 0 ]]; then
+        echo "Clang-format detected non-compliant code, please fix it by calling me again with '--fix' flag"
+        exit 1
+    fi
+else
+    for file in $SRC_TO_CHECK
+    do
+        echo "$file fixing..."
+        $CLANG_FORMAT_BIN -style=file -i $file
+    done
+fi

--- a/cpp/clang/clang-tidy.sh
+++ b/cpp/clang/clang-tidy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+if [ ! -f .clang-tidy ]; then
+    echo ".clang-tidy not found! Make ./code-quality/cpp/clang/setup-clang-config.sh to fix it."
+    exit 1
+fi
+
+# Default directories to check
+DIRS_TO_CHECK="include"
+EXCLUDED_DIRS=""
+
+for i in "$@"
+do
+case $i in
+    --include-dirs=*)
+    DIRS_TO_CHECK="${i#*=}"
+    shift
+    ;;
+    --exclude-dirs=*)
+    EXCLUDED_DIRS="${i#*=}"
+    shift
+    ;;
+    *)
+    echo "Not supported arg"
+    exit 1
+    ;;
+esac
+done
+
+SRC_TO_CHECK=$(find ${DIRS_TO_CHECK} ${EXCLUDED_DIRS} -name "*.h" -or -name "*.cpp")
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  NPROC="${NPROC:-$(nproc)}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  NPROC="${NPROC:-$(sysctl -n hw.physicalcpu)}"
+else
+  NPROC="${NPROC:-1}"
+fi
+
+run-clang-tidy-17 \
+    -j "${NPROC}" \
+    -clang-tidy-binary clang-tidy-17 \
+    -clang-apply-replacements-binary clang-apply-replacements-17 \
+    -p build \
+    $SRC_TO_CHECK

--- a/cpp/clang/readme.md
+++ b/cpp/clang/readme.md
@@ -1,0 +1,41 @@
+# How to setup clang in your project
+To begin with, these configs are based on clang tools 17+ versions, so in order to work with it you should update your clang tools (For installation example in docker you can refer to [embedded-tools](https://github.com/emlid/embedded-tools/blob/master/docker/Dockerfile)) project).
+
+Next, you should add code-quality as a submodule in the root of your project
+```bash
+git submodule add git@github.com:emlid/code-quality.git code-quality
+```
+
+Since `clang` is really dumb refers to working with config files the easiest way is to make a symbolic link from code-quality to your project so clang will find it. It can be done with `setup-clang-config.sh`:
+```bash
+./code-quality/cpp/clang/setup-clang-config.sh
+```
+This script will create links to files in your project. Add `.clang-*` line to your `.gitignore`. Also, don't forget to add the `setup-clang-config.sh` call to your linters CI setup.
+
+To launch checks you can use scripts with providing directories to check like that:
+```bash
+./code-quality/cpp/clang/clang-tidy.sh --include-dirs="include src examples"
+```
+
+Also you can use `--exclude-dirs` in case you want to ignore directories:
+```bash
+./code-quality/cpp/clang/clang-format.sh --include-dirs="include src examples" --exclude-dirs="include/stash"
+```
+
+To fully automize the process you can setup your `Makefile` like that:
+```bash
+clang-tidy: CMAKE_FLAGS += -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+clang-tidy: all
+	NPROC=$(NPROC) ./code-quality/cpp/clang/setup-clang-config.sh 
+	./code-quality/cpp/clang/clang-tidy.sh --include-dirs="include src examples"
+
+clang-format:
+	./code-quality/cpp/clang/setup-clang-config.sh 
+	./code-quality/cpp/clang/clang-format.sh --include-dirs="include src examples"
+
+clang-format-fix:
+	./code-quality/cpp/clang/setup-clang-config.sh 
+	./code-quality/cpp/clang/clang-format.sh --fix --include-dirs="include src examples"
+```
+
+Again, for a full setup example you can see [embedded-tools](https://github.com/emlid/embedded-tools) project. In case of questions do not hesitate to ask `@aleksandr.kovalenok` in Slack.

--- a/cpp/clang/setup-clang-config.sh
+++ b/cpp/clang/setup-clang-config.sh
@@ -1,0 +1,1 @@
+ln -sf code-quality/cpp/clang/.clang-* .


### PR DESCRIPTION
Here I added config files for `clang-format` and `clang-tidy`. Since some of them are just personal preferences I am open to a healthy discussion. But mostly they are still based on guidelines or recommendations.
Some options are just a legacy from RUD and RP, despite the fact I don't like some choices it would become a huge cosmetic job, so I just ported part of them here.  
`clang-format` options description: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
`clang-tidy` options description: https://clang.llvm.org/extra/clang-tidy/checks/list.html

While working on that task I remembered why I hate `clang` so much. Yes, it's a configuration process. You can't just say to `clang` "Hey buddy just take a config file from here, do not search for `.clang-format` in the root or create a default one and check it verbosely". `clang` is a powerful tool but this is pure pain through years.
![Screenshot from 2024-05-29 17-04-26](https://github.com/emlid/code-quality/assets/19861339/289430fd-701b-40ed-8384-90de3cd64ce2)

Because of that, I was forced to add a few lines of docs and script examples. This is the easiest way to handle custom configs for now.