### PR TITLE
Three missed moments in clang

### DIFF
--- a/cpp/clang/.clang-format
+++ b/cpp/clang/.clang-format
@@ -26,7 +26,7 @@ BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: true
+  AfterControlStatement: MultiLine
   AfterEnum:       true
   AfterFunction:   true
   AfterNamespace:  false

--- a/cpp/clang/.clang-format
+++ b/cpp/clang/.clang-format
@@ -71,7 +71,7 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        1
 IncludeIsMainRegex: '(Test)?$'
-IndentAccessModifiers: true
+IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: true
 IndentPPDirectives: None

--- a/cpp/clang/.clang-format
+++ b/cpp/clang/.clang-format
@@ -19,6 +19,7 @@ AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: Inline
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
 BitFieldColonSpacing: Both


### PR DESCRIPTION
1. **AlwaysBreakTemplateDeclarations** - removed it at first but then realized that the newer option was released only in version 19 and we don't have it yet, so returned it here
2. **AfterControlStatement** changed to MultiLine to save same line opening bracket notation
3. **IndentAccessModifiers** brings double indent. Don't want to play around and lose a couple of days to find a solution, so just removed it for now. 
Open issue - https://github.com/llvm/llvm-project/issues/61631

In few hours I will update https://github.com/emlid/reach-tools/pull/1 and we will see that it fix every mentioned problem