### PR TITLE
cpp: clang: Fix --exclude-dirs

### DIFF
--- a/cpp/clang/clang-format.sh
+++ b/cpp/clang/clang-format.sh
@@ -33,7 +33,18 @@ fi
 
 CLANG_FORMAT_BIN=clang-format-17
 
-SRC_TO_CHECK=$(find ${DIRS_TO_CHECK} ${EXCLUDED_DIRS} -name "*.h" -or -name "*.cpp")
+FIND_CMD="find"
+for DIR in $DIRS_TO_CHECK; do
+    FIND_CMD+=" $DIR"
+done
+
+FIND_CMD+=" -type f \( -name '*.h' -or -name '*.cpp' \)"
+
+for EX_DIR in $EXCLUDED_DIRS; do
+    FIND_CMD+=" -not -path '$EX_DIR/*'"
+done
+
+SRC_TO_CHECK=$(eval $FIND_CMD)
 
 if [[ ! $FIX ]]; then
     $CLANG_FORMAT_BIN -style=file -output-replacements-xml $SRC_TO_CHECK | grep "<replacement " > /dev/null 2>&1

--- a/cpp/clang/clang-tidy.sh
+++ b/cpp/clang/clang-tidy.sh
@@ -27,7 +27,18 @@ case $i in
 esac
 done
 
-SRC_TO_CHECK=$(find ${DIRS_TO_CHECK} ${EXCLUDED_DIRS} -name "*.h" -or -name "*.cpp")
+FIND_CMD="find"
+for DIR in $DIRS_TO_CHECK; do
+    FIND_CMD+=" $DIR"
+done
+
+FIND_CMD+=" -type f \( -name '*.h' -or -name '*.cpp' \)"
+
+for EX_DIR in $EXCLUDED_DIRS; do
+    FIND_CMD+=" -not -path '$EX_DIR/*'"
+done
+
+SRC_TO_CHECK=$(eval $FIND_CMD)
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   NPROC="${NPROC:-$(nproc)}"

--- a/cpp/clang/readme.md
+++ b/cpp/clang/readme.md
@@ -1,5 +1,5 @@
 # How to setup clang in your project
-To begin with, these configs are based on clang tools 17+ versions, so in order to work with it you should update your clang tools (For installation example in docker you can refer to [embedded-tools](https://github.com/emlid/embedded-tools/blob/master/docker/Dockerfile)) project).
+To begin with, these configs are based on clang tools 17+ versions, so in order to work with it you should update your clang tools (For installation example in docker you can refer to [reach-tools](https://github.com/emlid/reach-tools/blob/master/docker/Dockerfile)) project).
 
 Next, you should add code-quality as a submodule in the root of your project
 ```bash
@@ -38,4 +38,4 @@ clang-format-fix:
 	./code-quality/cpp/clang/clang-format.sh --fix --include-dirs="include src examples"
 ```
 
-Again, for a full setup example you can see [embedded-tools](https://github.com/emlid/embedded-tools) project. In case of questions do not hesitate to ask `@aleksandr.kovalenok` in Slack.
+Again, for a full setup example you can see [reach-tools](https://github.com/emlid/reach-tools) project. In case of questions do not hesitate to ask `@aleksandr.kovalenok` in Slack.


### PR DESCRIPTION
Made a silly mistake at first and `--exclude-dirs` option was broken. Fixed. At least now I tested it :)