### PR TITLE
clang files filter: add .c and .cc files

### DIFF
--- a/cpp/clang/clang-format.sh
+++ b/cpp/clang/clang-format.sh
@@ -38,7 +38,7 @@ for DIR in $DIRS_TO_CHECK; do
     FIND_CMD+=" $DIR"
 done
 
-FIND_CMD+=" -type f \( -name '*.h' -or -name '*.cpp' \)"
+FIND_CMD+=" -type f \( -name '*.h' -or -name '*.cpp' -or -name '*.cc' -or -name '*.c' \)"
 
 for EX_DIR in $EXCLUDED_DIRS; do
     FIND_CMD+=" -not -path '$EX_DIR/*'"

--- a/cpp/clang/clang-tidy.sh
+++ b/cpp/clang/clang-tidy.sh
@@ -32,7 +32,7 @@ for DIR in $DIRS_TO_CHECK; do
     FIND_CMD+=" $DIR"
 done
 
-FIND_CMD+=" -type f \( -name '*.h' -or -name '*.cpp' \)"
+FIND_CMD+=" -type f \( -name '*.h' -or -name '*.cpp' -or -name '*.cc' -or -name '*.c' \)"
 
 for EX_DIR in $EXCLUDED_DIRS; do
     FIND_CMD+=" -not -path '$EX_DIR/*'"


### PR DESCRIPTION
As was stated here https://github.com/emlid/radio-fw/pull/88 I forgot about `.c` files so clang fixing only `.cpp` files, so I added `.c` and `.cc` files to filter