### PR TITLE
Provide config file paths instead of linking

### DIFF
--- a/cpp/clang/clang-format.sh
+++ b/cpp/clang/clang-format.sh
@@ -4,6 +4,9 @@
 DIRS_TO_CHECK="include"
 EXCLUDED_DIRS=""
 
+# Config file path
+CONFIG_FILE="code-quality/cpp/clang/.clang-format"
+
 for i in "$@"
 do
 case $i in
@@ -26,11 +29,6 @@ case $i in
 esac
 done
 
-if [ ! -f .clang-format ]; then
-    echo ".clang-format not found! Make ./code-quality/cpp/clang/setup-clang-config.sh to fix it."
-    exit 1
-fi
-
 CLANG_FORMAT_BIN=clang-format-17
 
 FIND_CMD="find"
@@ -47,7 +45,7 @@ done
 SRC_TO_CHECK=$(eval $FIND_CMD)
 
 if [[ ! $FIX ]]; then
-    $CLANG_FORMAT_BIN -style=file -output-replacements-xml $SRC_TO_CHECK | grep "<replacement " > /dev/null 2>&1
+    $CLANG_FORMAT_BIN -style=file:$CONFIG_FILE -output-replacements-xml $SRC_TO_CHECK | grep "<replacement " > /dev/null 2>&1
 
     if [[ $? -eq 0 ]]; then
         echo "Clang-format detected non-compliant code, please fix it by calling me again with '--fix' flag"
@@ -57,6 +55,6 @@ else
     for file in $SRC_TO_CHECK
     do
         echo "$file fixing..."
-        $CLANG_FORMAT_BIN -style=file -i $file
+        $CLANG_FORMAT_BIN -style=file:$CONFIG_FILE -i $file
     done
 fi

--- a/cpp/clang/clang-tidy.sh
+++ b/cpp/clang/clang-tidy.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-if [ ! -f .clang-tidy ]; then
-    echo ".clang-tidy not found! Make ./code-quality/cpp/clang/setup-clang-config.sh to fix it."
-    exit 1
-fi
-
 # Default directories to check
 DIRS_TO_CHECK="include"
 EXCLUDED_DIRS=""
+
+CONFIG_FILE="code-quality/cpp/clang/.clang-tidy"
 
 for i in "$@"
 do
@@ -51,6 +48,7 @@ fi
 run-clang-tidy-17 \
     -j "${NPROC}" \
     -clang-tidy-binary clang-tidy-17 \
+    -config-file=$CONFIG_FILE \
     -clang-apply-replacements-binary clang-apply-replacements-17 \
     -p build \
     $SRC_TO_CHECK

--- a/cpp/clang/readme.md
+++ b/cpp/clang/readme.md
@@ -6,12 +6,6 @@ Next, you should add code-quality as a submodule in the root of your project
 git submodule add git@github.com:emlid/code-quality.git code-quality
 ```
 
-Since `clang` is really dumb refers to working with config files the easiest way is to make a symbolic link from code-quality to your project so clang will find it. It can be done with `setup-clang-config.sh`:
-```bash
-./code-quality/cpp/clang/setup-clang-config.sh
-```
-This script will create links to files in your project. Add `.clang-*` line to your `.gitignore`. Also, don't forget to add the `setup-clang-config.sh` call to your linters CI setup.
-
 To launch checks you can use scripts with providing directories to check like that:
 ```bash
 ./code-quality/cpp/clang/clang-tidy.sh --include-dirs="include src examples"
@@ -26,15 +20,12 @@ To fully automize the process you can setup your `Makefile` like that:
 ```bash
 clang-tidy: CMAKE_FLAGS += -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 clang-tidy: all
-	NPROC=$(NPROC) ./code-quality/cpp/clang/setup-clang-config.sh 
 	./code-quality/cpp/clang/clang-tidy.sh --include-dirs="include src examples"
 
 clang-format:
-	./code-quality/cpp/clang/setup-clang-config.sh 
 	./code-quality/cpp/clang/clang-format.sh --include-dirs="include src examples"
 
 clang-format-fix:
-	./code-quality/cpp/clang/setup-clang-config.sh 
 	./code-quality/cpp/clang/clang-format.sh --fix --include-dirs="include src examples"
 ```
 

--- a/cpp/clang/setup-clang-config.sh
+++ b/cpp/clang/setup-clang-config.sh
@@ -1,1 +1,0 @@
-ln -sf code-quality/cpp/clang/.clang-* .


### PR DESCRIPTION
I noticed flag options in newer clang and realized that we can provide filepath after `:`, no need to create links anymore

(tested on `reach-tools`)