### PR TITLE
C compatibility

### DIFF
--- a/cpp/clang/.clang-format
+++ b/cpp/clang/.clang-format
@@ -82,9 +82,9 @@ InsertBraces: true  # Be extra careful with that
 InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 IntegerLiteralSeparator:
-  Binary: 0
-  Decimal: 3
-  Hex: 0
+  Binary: -1
+  Decimal: -1
+  Hex: -1
 JavaScriptQuotes: Double
 JavaScriptWrapImports: true
 KeepEmptyLinesAtEOF: true


### PR DESCRIPTION
The purpose of this PR is to make code-quality C++ config compatible with C code since I don't want to have separate configs (at least for now)

- [x] `IntegerLiteralSeparator` group set to `-1` to remove all `'` from integers


Tested on `radio-fw`

@toshbi4  it would be nice if you could check this branch on `radio-fw` too just in case I missed something