### PR TITLE
Workaround for C99 (C++20) designated initialisers

### DIFF
--- a/cpp/clang/.clang-format
+++ b/cpp/clang/.clang-format
@@ -1,13 +1,13 @@
 ---
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: Right
+AlignArrayOfStructures: None
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: AcrossEmptyLinesAndComments
 AlignEscapedNewlines: Left
-AlignOperands: true
+AlignOperands: Align
 AlignTrailingComments: Always
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
@@ -39,6 +39,7 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
+BracedInitializerIndentWidth: 4
 BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: true
 BreakArrays: false


### PR DESCRIPTION
We got some problems with formatting designated initialisers (especially nested ones), so as far as clang has general problems with them I had to find workaround.
The problem was stated [here](https://github.com/emlid/radio-fw/pull/88#discussion_r1672423544) (all three comments below)

So, what changed:
1. `AlignArrayOfStructures`: `Right` -> `None`
Main workaround. Personally I like [this option](https://releases.llvm.org/17.0.1/tools/clang/docs/ClangFormatStyleOptions.html#alignarrayofstructures) but since it breaks initialisers I had to remove it, so for now I disabled aligning of structured arrays
2. `AlignOperands`: `true` -> `Align`
Just a typo, nothing really changed
3. `BracedInitializerIndentWidth`: `0` -> `4`
New helpful [option](https://releases.llvm.org/17.0.1/tools/clang/docs/ClangFormatStyleOptions.html#bracedinitializerindentwidth) for initialisers

**Before:**
```
...
static struct cat_variable lora_variables[] = {

    {// DR_INDEX
.type = CAT_VAR_INT_DEC,
     .data = NULL,
     .data_size = 0,
     .name = "+SF"    },

    {// BW_INDEX
.type = CAT_VAR_INT_DEC,
     .data = NULL,
     .data_size = 0,
     .name = "+BW"    },
...
static struct uhf_variables uhf_vars = {
    .fq_uhf = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.frequency,
               .data_size = sizeof(uhf_config.frequency),
               .name = "+FQUHF"},
    .tx_power = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.tx_power,
               .data_size = sizeof(uhf_config.tx_power),
               .name = "+TPUHF"},

    .air_rate = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.air_rate,
               .data_size = sizeof(uhf_config.air_rate),
               .name = "+ARUHF"},

    .protocol = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.protocol,
               .data_size = sizeof(uhf_config.protocol),
               .name = "+PROT" },

    .mode = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.mode,
               .data_size = sizeof(uhf_config.mode),
               .name = "+MODE" },
};
...
```
**After**:
```
...
static struct cat_variable lora_variables[] = {

  {// DR_INDEX
   .type = CAT_VAR_INT_DEC,
   .data = NULL,
   .data_size = 0,
   .name = "+SF"},

  {// BW_INDEX
   .type = CAT_VAR_INT_DEC,
   .data = NULL,
   .data_size = 0,
   .name = "+BW"},
...
static struct uhf_variables uhf_vars = {
  .fq_uhf = {.type = CAT_VAR_UINT_DEC,
             .data = (void*)&uhf_config.frequency,
             .data_size = sizeof(uhf_config.frequency),
             .name = "+FQUHF"},
  .tx_power = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.tx_power,
               .data_size = sizeof(uhf_config.tx_power),
               .name = "+TPUHF"},

  .air_rate = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.air_rate,
               .data_size = sizeof(uhf_config.air_rate),
               .name = "+ARUHF"},

  .protocol = {.type = CAT_VAR_UINT_DEC,
               .data = (void*)&uhf_config.protocol,
               .data_size = sizeof(uhf_config.protocol),
               .name = "+PROT"},

  .mode = {.type = CAT_VAR_UINT_DEC,
           .data = (void*)&uhf_config.mode,
           .data_size = sizeof(uhf_config.mode),
           .name = "+MODE"},
};
...
```