### PR TITLE
Fix gitlint regexp

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -16,4 +16,4 @@ line-length=200
 min-length=5
 
 [author-valid-email]
-regex=(.+@emlid.com|.+(dependabot)\[(bot)\]@users.noreply.github.com)
+regex=((.+@emlid.com)|(.+(dependabot)\[(bot)\]@users.noreply.github.com))

--- a/git/gitlint
+++ b/git/gitlint
@@ -16,4 +16,4 @@ line-length=200
 min-length=5
 
 [author-valid-email]
-regex=((.+@emlid.com)|(.+(dependabot)\[(bot)\]@users.noreply.github.com))
+regex=((.+@emlid\.com)|(.+(dependabot)\[(bot)\]@users\.noreply\.github\.com))


### PR DESCRIPTION
# Problem

In reach platform CI we use actions bot to commit to changelog. And his email is not valid.

# Solution

- Separate valid emails in easier to read groups
- Strictly check dots
- ~~Add regexp for exactly `github-actions[bot]@users.noreply.github.com` email~~
  After a brief discussion with @paivin-dn, we've decided that it would be better to use [Emlid Builder Bot](https://github.com/EmlidBuilderBot) credentials instead, so email will be `"builderbot@emlid.com"` and username is `Builder Bot`

# How it was checked

Through regex101.com:
![image](https://github.com/user-attachments/assets/bacdbcd5-b5e9-4b2b-a314-ab47f01be7a3)
