### PR TITLE
git: allow renovate bot commits

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -16,4 +16,4 @@ line-length=200
 min-length=5
 
 [author-valid-email]
-regex=((.+@emlid\.com)|(.+(dependabot)\[(bot)\]@users\.noreply\.github\.com))
+regex=((.+@emlid\.com)|(.+(dependabot|renovate)\[(bot)\]@users\.noreply\.github\.com))


### PR DESCRIPTION
We added the [renovate](https://docs.renovatebot.com/) bot to some cloud repos(flow360-frontend as an example). This bot will commit from a special bot user that we cannot change([example](https://github.com/emlid/cloud-flow360-frontend/pull/629/commits/e3572da996110f1f67af8d480b827ed9da87abc2)). Therefore, I added this bot-user to the `author-valid-email` gitlint section