### PR TITLE
Python: introduce checks for `isort` in Ruff

### DIFF
--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -48,6 +48,8 @@ select = [
     "F",
     # Pylint,
     "PL",
+    # isort
+    "I"
 ]
 ignore = [
   # those are not yet supported by ruff


### PR DESCRIPTION
> [!warning]
> Consider this PR as a vote. It is up to us how strict we want our rules to be.

Not that it is really necessary, but my syntax highlighter started to complain about that.

We can use it to sort imports with `ruff check --fix`.

I've tested it with reach-platform, and it seems to be working good enough. But I'm not 100% sure if it is worth enabling this check or not.

[Here is how Ruff docs describe it](https://docs.astral.sh/ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort):

> Ruff's import sorting is intended to be near-equivalent to isort's when using isort's profile = "black".
>
> There are a few known differences in how Ruff and isort treat aliased imports, and in how Ruff and isort treat inline comments in some cases (see: [#1381](https://github.com/astral-sh/ruff/issues/1381), [#2104](https://github.com/astral-sh/ruff/issues/2104)).
>
> For example, Ruff tends to group non-aliased imports from the same module:
>
> ```python
> from numpy import cos, int8, int16, int32, int64, tan, uint8, uint16, uint32, uint64
> from numpy import sin as np_sin
> ```
>
> Whereas isort splits them into separate import statements at each aliased boundary:
>
> ```python
> from numpy import cos, int8, int16, int32, int64
> from numpy import sin as np_sin
> from numpy import tan, uint8, uint16, uint32, uint64
> ```
>
> Ruff also correctly classifies some modules as standard-library that aren't recognized by isort, like \_string and idlelib.
>
> Like isort, Ruff's import sorting is compatible with Black.