### PR TITLE
gitlint: support GitHub Copilot agent's emails as commit author (CLD-5728)

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -16,4 +16,4 @@ line-length=200
 min-length=5
 
 [author-valid-email]
-regex=((.+@emlid\.com)|(.+(dependabot|renovate)\[(bot)\]@users\.noreply\.github\.com))
+regex=((.+@emlid\.com)|(.+(dependabot|renovate|Copilot)(\[(bot)\])?@users\.noreply\.github\.com))


### PR DESCRIPTION
## Motivation

GitHub Copilot agents use emails like `198982749+Copilot@users.noreply.github.com`, which are not supported by the current `gitlint` config.

## Solution

I believe we can extend the current configuration a bit more, before completely giving up and weakening the
match restriction to simply `@users.noreply.github.com`.

## How it was tested

Gitlint is failing in https://github.com/emlid/cloud-storage/pull/85:
```
Commit 5a8d83e91d:
-: M1 Author email for commit is invalid: "198982749+Copilot@users.noreply.github.com
```

Once I checked out the current branch it's now went away.
