### PR TITLE
gitlint: expand commit authors regex with `copilot` entry to support GitHub Copilot agent's emails

### DIFF
--- a/git/gitlint
+++ b/git/gitlint
@@ -16,4 +16,4 @@ line-length=200
 min-length=5
 
 [author-valid-email]
-regex=((.+@emlid\.com)|(.+(dependabot|renovate|Copilot)(\[(bot)\])?@users\.noreply\.github\.com))
+regex=((.+@emlid\.com)|(.+(dependabot|renovate|[Cc]opilot)(\[(bot)\])?@users\.noreply\.github\.com))


### PR DESCRIPTION
## Motivation

We discovered that some Copilot agents use a lowercase `copilot` local part, which fails the existing GitLint author regex.
Allow lowercase `copilot` to keep CI green without broadening the match beyond the known bot names.

## Solution

Expanded the current list of allowed authors with `copilot`.