### PR TITLE
python: pylintrc: remove "suggestion-mode" option

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -94,10 +94,6 @@ py-version=3.10
 # Discover python modules and packages in the file system subtree.
 recursive=no
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no


### PR DESCRIPTION
It's deprecated starting from Pylint 4.0: https://pylint.readthedocs.io/en/latest/whatsnew/4/4.0/index.html